### PR TITLE
Define onlyIfUnchanged for ETag support

### DIFF
--- a/sdk/search/Azure.Search.Documents/src/SearchServiceClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/SearchServiceClient.cs
@@ -1433,7 +1433,11 @@ namespace Azure.Search.Documents
         /// Creates a new synonym map or updates an existing synonym map.
         /// </summary>
         /// <param name="synonymMap">Required. The <see cref="SynonymMap"/> to create or update.</param>
-        /// <param name="options">Optional <see cref="SearchConditionalOptions"/> to customize the operation's behavior.</param>
+        /// <param name="onlyIfUnchanged">
+        /// True to throw a <see cref="RequestFailedException"/> if the <see cref="SynonymMap.ETag"/> does not match the current service version;
+        /// otherwise, the current service version will be overwritten.
+        /// </param>
+        /// <param name="options">Optional <see cref="SearchRequestOptions"/> to customize the operation's behavior.</param>
         /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> to propagate notifications that the operation should be canceled.</param>
         /// <returns>
         /// The <see cref="Response{T}"/> from the server containing the <see cref="SynonymMap"/> that was created.
@@ -1444,20 +1448,25 @@ namespace Azure.Search.Documents
         [ForwardsClientCalls]
         public virtual Response<SynonymMap> CreateOrUpdateSynonymMap(
             SynonymMap synonymMap,
-            SearchConditionalOptions options = null,
+            bool onlyIfUnchanged = false,
+            SearchRequestOptions options = null,
             CancellationToken cancellationToken = default) =>
             SynonymMapsClient.CreateOrUpdate(
                 synonymMap?.Name,
                 synonymMap,
                 options?.ClientRequestId,
-                options?.IfMatch?.ToString(),
-                options?.IfNoneMatch?.ToString(),
+                onlyIfUnchanged ? synonymMap?.ETag?.ToString() : null,
+                null,
                 cancellationToken);
 
         /// <summary>
         /// Creates a new synonym map or updates an existing synonym map.
         /// </summary>
         /// <param name="synonymMap">Required. The <see cref="SynonymMap"/> to create or update.</param>
+        /// <param name="onlyIfUnchanged">
+        /// True to throw a <see cref="RequestFailedException"/> if the <see cref="SynonymMap.ETag"/> does not match the current service version;
+        /// otherwise, the current service version will be overwritten.
+        /// </param>
         /// <param name="options">Optional <see cref="SearchConditionalOptions"/> to customize the operation's behavior.</param>
         /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> to propagate notifications that the operation should be canceled.</param>
         /// <returns>
@@ -1469,57 +1478,68 @@ namespace Azure.Search.Documents
         [ForwardsClientCalls]
         public virtual async Task<Response<SynonymMap>> CreateOrUpdateSynonymMapAsync(
             SynonymMap synonymMap,
+            bool onlyIfUnchanged = false,
             SearchConditionalOptions options = null,
             CancellationToken cancellationToken = default) =>
             await SynonymMapsClient.CreateOrUpdateAsync(
                 synonymMap?.Name,
                 synonymMap,
                 options?.ClientRequestId,
-                options?.IfMatch?.ToString(),
-                options?.IfNoneMatch?.ToString(),
+                onlyIfUnchanged ? synonymMap?.ETag?.ToString() : null,
+                null,
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
         /// Deletes a synonym map.
         /// </summary>
-        /// <param name="synonymMapName">The name of the synonym map to delete.</param>
-        /// <param name="options">Optional <see cref="SearchConditionalOptions"/> to customize the operation's behavior.</param>
+        /// <param name="synonymMap">The <see cref="SynonymMap"/> to delete.</param>
+        /// <param name="onlyIfUnchanged">
+        /// True to throw a <see cref="RequestFailedException"/> if the <see cref="SynonymMap.ETag"/> does not match the current service version;
+        /// otherwise, the current service version will be overwritten.
+        /// </param>
+        /// <param name="options">Optional <see cref="SearchRequestOptions"/> to customize the operation's behavior.</param>
         /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> to propagate notifications that the operation should be canceled.</param>
         /// <returns>The <see cref="Response"/> from the server.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="synonymMapName"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="synonymMap"/> or <see cref="SynonymMap.Name"/> is null.</exception>
         /// <exception cref="RequestFailedException">Thrown when a failure is returned by the Search service.</exception>
         [ForwardsClientCalls]
         public virtual Response DeleteSynonymMap(
-            string synonymMapName,
-            SearchConditionalOptions options = null,
+            SynonymMap synonymMap,
+            bool onlyIfUnchanged = false,
+            SearchRequestOptions options = null,
             CancellationToken cancellationToken = default) =>
             SynonymMapsClient.Delete(
-                synonymMapName,
+                synonymMap?.Name,
                 options?.ClientRequestId,
-                options?.IfMatch?.ToString(),
-                options?.IfNoneMatch?.ToString(),
+                onlyIfUnchanged ? synonymMap?.ETag?.ToString() : null,
+                null,
                 cancellationToken);
 
         /// <summary>
         /// Deletes a synonym map.
         /// </summary>
-        /// <param name="synonymMapName">The name of the synonym map to delete.</param>
-        /// <param name="options">Optional <see cref="SearchConditionalOptions"/> to customize the operation's behavior.</param>
+        /// <param name="synonymMap">The <see cref="SynonymMap"/> to delete.</param>
+        /// <param name="onlyIfUnchanged">
+        /// True to throw a <see cref="RequestFailedException"/> if the <see cref="SynonymMap.ETag"/> does not match the current service version;
+        /// otherwise, the current service version will be overwritten.
+        /// </param>
+        /// <param name="options">Optional <see cref="SearchRequestOptions"/> to customize the operation's behavior.</param>
         /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> to propagate notifications that the operation should be canceled.</param>
         /// <returns>The <see cref="Response"/> from the server.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="synonymMapName"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="synonymMap"/> or <see cref="SynonymMap.Name"/> is null.</exception>
         /// <exception cref="RequestFailedException">Thrown when a failure is returned by the Search service.</exception>
         [ForwardsClientCalls]
         public virtual async Task<Response> DeleteSynonymMapAsync(
-            string synonymMapName,
-            SearchConditionalOptions options = null,
+            SynonymMap synonymMap,
+            bool onlyIfUnchanged = false,
+            SearchRequestOptions options = null,
             CancellationToken cancellationToken = default) =>
             await SynonymMapsClient.DeleteAsync(
-                synonymMapName,
+                synonymMap?.Name,
                 options?.ClientRequestId,
-                options?.IfMatch?.ToString(),
-                options?.IfNoneMatch?.ToString(),
+                onlyIfUnchanged ? synonymMap?.ETag?.ToString() : null,
+                null,
                 cancellationToken)
                 .ConfigureAwait(false);
 

--- a/sdk/search/Azure.Search.Documents/tests/SearchServiceClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchServiceClientTests.cs
@@ -261,31 +261,41 @@ namespace Azure.Search.Documents.Tests
 
             SearchServiceClient client = resources.GetServiceClient();
 
-            SynonymMap map = await client.CreateSynonymMapAsync(new SynonymMap(synonymMapName, "msft=>Microsoft"));
-            Assert.AreEqual(synonymMapName, map.Name);
-            Assert.AreEqual("solr", map.Format);
-            Assert.AreEqual("msft=>Microsoft", map.Synonyms);
+            SynonymMap createdMap = await client.CreateSynonymMapAsync(new SynonymMap(synonymMapName, "msft=>Microsoft"));
+            Assert.AreEqual(synonymMapName, createdMap.Name);
+            Assert.AreEqual("solr", createdMap.Format);
+            Assert.AreEqual("msft=>Microsoft", createdMap.Synonyms);
 
-            map = await client.CreateOrUpdateSynonymMapAsync(new SynonymMap(synonymMapName, "ms,msft=>Microsoft"), new SearchConditionalOptions { IfMatch = map.ETag });
-            Assert.AreEqual(synonymMapName, map.Name);
-            Assert.AreEqual("solr", map.Format);
-            Assert.AreEqual("ms,msft=>Microsoft", map.Synonyms);
+            SynonymMap updatedMap = await client.CreateOrUpdateSynonymMapAsync(
+                new SynonymMap(synonymMapName, "ms,msft=>Microsoft")
+                {
+                    ETag = createdMap.ETag,
+                },
+                onlyIfUnchanged: true);
+            Assert.AreEqual(synonymMapName, updatedMap.Name);
+            Assert.AreEqual("solr", updatedMap.Format);
+            Assert.AreEqual("ms,msft=>Microsoft", updatedMap.Synonyms);
 
             RequestFailedException ex = await CatchAsync<RequestFailedException>(async () =>
-                await client.CreateOrUpdateSynonymMapAsync(new SynonymMap(synonymMapName, "ms,msft=>Microsoft"), new SearchConditionalOptions { IfNoneMatch = map.ETag }));
+                await client.CreateOrUpdateSynonymMapAsync(
+                    new SynonymMap(synonymMapName, "ms,msft=>Microsoft")
+                    {
+                        ETag = createdMap.ETag,
+                    },
+                    onlyIfUnchanged: true));
             Assert.AreEqual((int)HttpStatusCode.PreconditionFailed, ex.Status);
 
             Response<IReadOnlyList<SynonymMap>> mapsResponse = await client.GetSynonymMapsAsync(new[] { nameof(SynonymMap.Name) });
             foreach (SynonymMap namedMap in mapsResponse.Value)
             {
-                if (string.Equals(map.Name, namedMap.Name, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(updatedMap.Name, namedMap.Name, StringComparison.OrdinalIgnoreCase))
                 {
                     SynonymMap fetchedMap = await client.GetSynonymMapAsync(namedMap.Name);
-                    Assert.AreEqual(map.Synonyms, fetchedMap.Synonyms);
+                    Assert.AreEqual(updatedMap.Synonyms, fetchedMap.Synonyms);
                 }
             }
 
-            await client.DeleteSynonymMapAsync(map.Name, new SearchConditionalOptions { IfMatch = map.ETag });
+            await client.DeleteSynonymMapAsync(updatedMap, onlyIfUnchanged: true);
         }
 
         /// <summary>

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CrudSynonymMaps.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CrudSynonymMaps.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "traceparent": "00-71f2cffa0781214fb0cc3e042917281c-991713398d5ff64d-00",
+        "traceparent": "00-62ebef1327ee2e41a115f776984d6e49-9bdbe539d90c3943-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e774d64a0e1ee1ed26d81ec8b16be261",
@@ -25,11 +25,11 @@
         "Cache-Control": "no-cache",
         "Content-Length": "216",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "44",
-        "ETag": "W/\u00220x8D7E31BF62EACCA\u0022",
+        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
+        "elapsed-time": "71",
+        "ETag": "W/\u00220x8D7E5A1F324FEDE\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -37,8 +37,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-psxebbcy.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E31BF62EACCA\u0022",
+        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7E5A1F324FEDE\u0022",
         "name": "vsluedsr",
         "format": "solr",
         "synonyms": "msft=\u003EMicrosoft",
@@ -46,17 +46,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "72",
+        "Content-Length": "118",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E31BF62EACCA\u0022",
+        "If-Match": "\u00220x8D7E5A1F324FEDE\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-0a81605fc26b6d4786d3194736c6e6c0-667f590a574f7a4d-00",
+        "traceparent": "00-4b420d5ce49aa04088a43880eacc0faa-e20acb1dbb02964c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "890ba43bad9d8bc6db7ea8d0f34ce722",
@@ -65,16 +65,17 @@
       "RequestBody": {
         "name": "vsluedsr",
         "format": "solr",
-        "synonyms": "ms,msft=\u003EMicrosoft"
+        "synonyms": "ms,msft=\u003EMicrosoft",
+        "@odata.etag": "\u00220x8D7E5A1F324FEDE\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "219",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "33",
-        "ETag": "W/\u00220x8D7E31BF63C1D8F\u0022",
+        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
+        "elapsed-time": "29",
+        "ETag": "W/\u00220x8D7E5A1F339C315\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -83,8 +84,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-psxebbcy.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E31BF63C1D8F\u0022",
+        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7E5A1F339C315\u0022",
         "name": "vsluedsr",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
@@ -92,17 +93,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "72",
+        "Content-Length": "118",
         "Content-Type": "application/json",
-        "If-None-Match": "\u00220x8D7E31BF63C1D8F\u0022",
+        "If-Match": "\u00220x8D7E5A1F324FEDE\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-7a961f91df2f9c49b64c83b823e5d35a-c3dbea4a8af1d24d-00",
+        "traceparent": "00-8da18b0ae64d514397d0c835f0e18b69-dc3cb00c8970ee4c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d6d9fa27c35a394621cb45794f7a1697",
@@ -111,7 +112,8 @@
       "RequestBody": {
         "name": "vsluedsr",
         "format": "solr",
-        "synonyms": "ms,msft=\u003EMicrosoft"
+        "synonyms": "ms,msft=\u003EMicrosoft",
+        "@odata.etag": "\u00220x8D7E5A1F324FEDE\u0022"
       },
       "StatusCode": 412,
       "ResponseHeaders": {
@@ -119,8 +121,8 @@
         "Content-Language": "en",
         "Content-Length": "160",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "13",
+        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
+        "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -136,13 +138,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps?$select=name\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps?$select=name\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-21635eb1c22cb040ad2d4b6add6a4981-331f4c0121efd440-00",
+        "traceparent": "00-6be419ea39ca964394f95689fca1ab0f-a4f87dab9a100549-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9a86040cbd479da90fe80c9f661deeda",
@@ -154,8 +156,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "122",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "11",
+        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
+        "elapsed-time": "93",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -164,7 +166,7 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-psxebbcy.search.windows.net/$metadata#synonymmaps(name)",
+        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps(name)",
         "value": [
           {
             "name": "vsluedsr"
@@ -173,13 +175,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-d77350fdaef682418474397513f40258-251539fafaa5264b-00",
+        "traceparent": "00-75a2a36bc870834fabb36847d6ac726d-ac402f3d3ab2d64b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b7a0fcf00c9278065ed268d2674c3c60",
@@ -191,9 +193,9 @@
         "Cache-Control": "no-cache",
         "Content-Length": "219",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "9",
-        "ETag": "W/\u00220x8D7E31BF63C1D8F\u0022",
+        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
+        "elapsed-time": "26",
+        "ETag": "W/\u00220x8D7E5A1F339C315\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -202,8 +204,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-psxebbcy.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E31BF63C1D8F\u0022",
+        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7E5A1F339C315\u0022",
         "name": "vsluedsr",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
@@ -211,14 +213,14 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "If-Match": "\u00220x8D7E31BF63C1D8F\u0022",
-        "traceparent": "00-5fa1955c407bc64cb9ec7f3cc86cdc31-00c8c5e4752a874e-00",
+        "If-Match": "\u00220x8D7E5A1F339C315\u0022",
+        "traceparent": "00-f70e9f287e8cae4faa92d16c6d583a6c-545c8a684179b748-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "efc311684dc569da513cc771b7a7d304",
@@ -228,8 +230,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "20",
+        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
+        "elapsed-time": "25",
         "Expires": "-1",
         "Pragma": "no-cache",
         "request-id": "efc31168-4dc5-69da-513c-c771b7a7d304",
@@ -240,7 +242,7 @@
   ],
   "Variables": {
     "RandomSeed": "1266633341",
-    "SearchIndexName": "fuogpjxx",
-    "SearchServiceName": "azs-net-psxebbcy"
+    "SearchIndexName": "tobsblqg",
+    "SearchServiceName": "azs-net-upjoqfhr"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CrudSynonymMapsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CrudSynonymMapsAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "traceparent": "00-b57863b3906b2f4e8bcee83621a5042f-00c3f09cb296654a-00",
+        "traceparent": "00-7f727d4e9cd7b04398a55987ed64d08b-53c9f4d83f256e42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c02069d540fd192627e03b9f134bed62",
@@ -25,11 +25,11 @@
         "Cache-Control": "no-cache",
         "Content-Length": "216",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "28",
-        "ETag": "W/\u00220x8D7E31BF6928FD9\u0022",
+        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
+        "elapsed-time": "20",
+        "ETag": "W/\u00220x8D7E5A1F38CACFD\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -37,8 +37,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-psxebbcy.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E31BF6928FD9\u0022",
+        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7E5A1F38CACFD\u0022",
         "name": "byaqwdpt",
         "format": "solr",
         "synonyms": "msft=\u003EMicrosoft",
@@ -46,17 +46,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "72",
+        "Content-Length": "118",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E31BF6928FD9\u0022",
+        "If-Match": "\u00220x8D7E5A1F38CACFD\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-001d7ff04e23aa40beffd438879481a0-98a20075c6466a47-00",
+        "traceparent": "00-7e6dd551d4aee1429c39aa5959ed78c1-6dea2a5606785246-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "0b9c28133e0e9e04f52c78921f0b1fc4",
@@ -65,16 +65,17 @@
       "RequestBody": {
         "name": "byaqwdpt",
         "format": "solr",
-        "synonyms": "ms,msft=\u003EMicrosoft"
+        "synonyms": "ms,msft=\u003EMicrosoft",
+        "@odata.etag": "\u00220x8D7E5A1F38CACFD\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "219",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "24",
-        "ETag": "W/\u00220x8D7E31BF69B92B8\u0022",
+        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
+        "elapsed-time": "19",
+        "ETag": "W/\u00220x8D7E5A1F393B326\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -83,8 +84,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-psxebbcy.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E31BF69B92B8\u0022",
+        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7E5A1F393B326\u0022",
         "name": "byaqwdpt",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
@@ -92,17 +93,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "72",
+        "Content-Length": "118",
         "Content-Type": "application/json",
-        "If-None-Match": "\u00220x8D7E31BF69B92B8\u0022",
+        "If-Match": "\u00220x8D7E5A1F38CACFD\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-8a357a830c7fa64aae83aefb34fc678e-58685451f5c5e64a-00",
+        "traceparent": "00-02be3532633a38418ddda521ef20e338-6341a4636372c340-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "36a22e1a3354ac4d565b1f8fdf1033d3",
@@ -111,7 +112,8 @@
       "RequestBody": {
         "name": "byaqwdpt",
         "format": "solr",
-        "synonyms": "ms,msft=\u003EMicrosoft"
+        "synonyms": "ms,msft=\u003EMicrosoft",
+        "@odata.etag": "\u00220x8D7E5A1F38CACFD\u0022"
       },
       "StatusCode": 412,
       "ResponseHeaders": {
@@ -119,8 +121,8 @@
         "Content-Language": "en",
         "Content-Length": "160",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "14",
+        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
+        "elapsed-time": "52",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -136,13 +138,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps?$select=name\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps?$select=name\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-d220c65b720e9d4da7dffb3f8e838480-68900954dd329247-00",
+        "traceparent": "00-1597a7c9a9cf9346b23341451f5ed194-d707a95597fba84f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5043667597c197906482cad0c793f91b",
@@ -154,7 +156,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "122",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
+        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
         "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -164,7 +166,7 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-psxebbcy.search.windows.net/$metadata#synonymmaps(name)",
+        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps(name)",
         "value": [
           {
             "name": "byaqwdpt"
@@ -173,13 +175,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-7f764a604959704da257a6406da92b62-b3ca8cb94b1f8341-00",
+        "traceparent": "00-224b638cb0d54346904bea57b795f07b-eaa4973ec0757146-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e58477c0b6a8df0ddbf0b5b31e74bee5",
@@ -191,9 +193,9 @@
         "Cache-Control": "no-cache",
         "Content-Length": "219",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
+        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
         "elapsed-time": "5",
-        "ETag": "W/\u00220x8D7E31BF69B92B8\u0022",
+        "ETag": "W/\u00220x8D7E5A1F393B326\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -202,8 +204,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-psxebbcy.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E31BF69B92B8\u0022",
+        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7E5A1F393B326\u0022",
         "name": "byaqwdpt",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
@@ -211,14 +213,14 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-psxebbcy.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "If-Match": "\u00220x8D7E31BF69B92B8\u0022",
-        "traceparent": "00-518efc1dd7919443ac302832e5d5d207-35d4949d3621714b-00",
+        "If-Match": "\u00220x8D7E5A1F393B326\u0022",
+        "traceparent": "00-78d477d2fa1a1d4ba479a1330da7acc7-d4e6a0ae0d1afa40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200417.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b81ca4f9cfc882029d0bd1d2687ce4c3",
@@ -228,8 +230,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Fri, 17 Apr 2020 22:09:13 GMT",
-        "elapsed-time": "11",
+        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
+        "elapsed-time": "21",
         "Expires": "-1",
         "Pragma": "no-cache",
         "request-id": "b81ca4f9-cfc8-8202-9d0b-d1d2687ce4c3",
@@ -240,7 +242,7 @@
   ],
   "Variables": {
     "RandomSeed": "43964750",
-    "SearchIndexName": "fuogpjxx",
-    "SearchServiceName": "azs-net-psxebbcy"
+    "SearchIndexName": "tobsblqg",
+    "SearchServiceName": "azs-net-upjoqfhr"
   }
 }


### PR DESCRIPTION
This was suggested to match what AppConfiguration does. It simplifies it, with no practical reason for IfNoneMatch. We could always add that later as well.